### PR TITLE
[UPDATE] Java byte code compatibility to 11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,13 +32,16 @@ android {
             )
         }
     }
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
+
     buildFeatures {
         compose = true
     }


### PR DESCRIPTION
This pull request includes changes to the `app/build.gradle.kts` file to update the Java and Kotlin compatibility versions. The most important changes are:

### Build Configuration Updates:

* Updated `sourceCompatibility` and `targetCompatibility` from `JavaVersion.VERSION_1_8` to `JavaVersion.VERSION_11`. (`app/build.gradle.kts`)
* Updated `jvmTarget` in `kotlinOptions` from `1.8` to `11`. (`app/build.gradle.kts`)

---

Fixes following warning

```
> Task :app:compileDebugJavaWithJavac
Java compiler version 21 has deprecated support for compiling with source/target version 8.
Try one of the following options:
    1. [Recommended] Use Java toolchain with a lower language version
    2. Set a higher source/target version
    3. Use a lower version of the JDK running the build (if you're not using Java toolchain)
For more details on how to configure these settings, see https://developer.android.com/build/jdks.
To suppress this warning, set android.javaCompile.suppressSourceTargetDeprecationWarning=true in gradle.properties.
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
Java compiler has deprecated support for compiling with source/target compatibility version 8.
Set Java Toolchain to 17
Change Java language level and jvmTarget to 11 in all modules if using a lower level.
Pick a different compatibility level...
Pick a different JDK to run Gradle...
More information...

3 warnings
```