### PR TITLE
[UPDATE] Added setup gradle task for faster setup

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -1,4 +1,4 @@
-name: Android CI Post Merge Check
+name: Post Merge Check
 # Run extra build and checks to ensure `main` is functioning right.
 
 on:
@@ -19,22 +19,13 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      # Automatic gradle caching using `actions/cache@v4`
+      # https://github.com/gradle/actions/tree/main/setup-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Run Linter
         run: ./gradlew lint
 
       - name: Build with Gradle
         run: ./gradlew build
-
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
-          cache: gradle
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      # Automatic gradle caching using `actions/cache@v4`
+      # https://github.com/gradle/actions/tree/main/setup-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Run Linter
         run: ./gradlew lintKotlin
@@ -35,14 +36,3 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew assembleDebug
-
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Gradle Dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-


### PR DESCRIPTION
Potentially faster.

Why use the setup-gradle action?

It is possible to directly invoke Gradle in your workflow, and the actions/setup-java@v4 action provides a simple way to cache Gradle dependencies.

However, the setup-gradle action offers a several advantages over this approach:

    Easily configure your workflow to use a specific version of Gradle using the gradle-version parameter. Gradle distributions are automatically downloaded and cached.
    More sophisticated and more efficient caching of Gradle User Home between invocations, compared to setup-java and most custom configurations using actions/cache. More details below.
    Detailed reporting of cache usage and cache configuration options allow you to optimize the use of the GitHub actions cache.
    Generate and Submit a GitHub Dependency Graph for your project, enabling Dependabot security alerts.
    Automatic capture of Build Scan® links from the build, making them easier to locate in workflow runs.

The setup-gradle action is designed to provide these benefits with minimal configuration. These features work both when Gradle is executed via setup-gradle and for any Gradle execution in subsequent steps.