### PR TITLE
[EXPERIMENT] With ` --parallel --daemon` flag for CI job

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Linter
-        run: ./gradlew lintKotlin
+        run: ./gradlew lintKotlin --parallel --daemon
 
       - name: Run test
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest --parallel --daemon
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug --parallel --daemon

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,5 +28,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Run Linter
+        run: ./gradlew lintKotlin --parallel --daemon
+
+      - name: Run test
+        run: ./gradlew testDebugUnitTest --parallel --daemon
+
       - name: Build with Gradle
-        run: ./gradlew lintKotlin testDebugUnitTest assembleDebug --parallel --daemon
+        run: ./gradlew assembleDebug --parallel --daemon

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,11 +28,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run Linter
-        run: ./gradlew lintKotlin --parallel --daemon
-
-      - name: Run test
-        run: ./gradlew testDebugUnitTest --parallel --daemon
-
       - name: Build with Gradle
-        run: ./gradlew assembleDebug --parallel --daemon
+        run: ./gradlew lintKotlin testDebugUnitTest assembleDebug --parallel --daemon


### PR DESCRIPTION
## v2

This pull request includes a change to the `.github/workflows/android.yml` file to optimize the Gradle build process by combining multiple steps into a single command.

Workflow optimization:

* [`.github/workflows/android.yml`](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L31-R32): Combined the `lintKotlin`, `testDebugUnitTest`, and `assembleDebug` commands into a single Gradle command to run them in parallel with the daemon option enabled.

## v1

This pull request includes updates to the Gradle commands in the Android workflow file to improve build efficiency.

* [`.github/workflows/android.yml`](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L32-R38): Updated the Gradle commands to use the `--parallel` and `--daemon` options for the `lintKotlin`, `testDebugUnitTest`, and `assembleDebug` tasks to enhance performance and reduce build times.


Related #16