### PR TITLE
[UPDATE] Use more points from semantic segments

### DIFF
--- a/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
+++ b/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
@@ -131,21 +131,23 @@ class TimelineDataPresenter
                         }
                     }*/
 
-                val latLngList: List<LatLng> =
+                val latLngVisitList: List<LatLng> =
                     timelineData.semanticSegments.mapNotNull {
                         // Only pick the visit location
-                        it.visit?.topCandidate?.placeLocation?.let { placeLocation ->
-                            val latLng = placeLocation.latLng.split(", ")
-                            LatLng(
-                                // latitude =
-                                latLng[0].removeSuffix("°").toDouble(),
-                                // longitude =
-                                latLng[1].removeSuffix("°").toDouble(),
-                            )
-                        }
+                        it.visit
+                            ?.topCandidate
+                            ?.placeLocation
+                            ?.latLng
+                            ?.toLatLng()
                     }
 
-                return latLngList.mapIndexed { index, latLng ->
+                val latLngPathList: List<LatLng> =
+                    timelineData.semanticSegments
+                        .map {
+                            it.timelinePath.map { timelinePoint -> timelinePoint.point.toLatLng() }
+                        }.flatten()
+
+                return latLngVisitList.plus(latLngPathList).mapIndexed { index, latLng ->
                     TimelineClusterItem(
                         itemPosition = latLng,
                         itemTitle = "Item $index",
@@ -301,4 +303,12 @@ data class TimelineClusterItem(
     override fun getSnippet(): String = itemSnippet
 
     override fun getZIndex(): Float = itemZIndex
+}
+
+private fun String.toLatLng(): LatLng {
+    val latLng = this.split(", ")
+    return LatLng(
+        latLng[0].removeSuffix("°").toDouble(),
+        latLng[1].removeSuffix("°").toDouble(),
+    )
 }

--- a/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
+++ b/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
@@ -118,18 +118,10 @@ class TimelineDataPresenter
                     "Parsed timeline data. Raw signals: ${timelineData.rawSignals.size}, Semantic Segments: ${timelineData.semanticSegments.size}",
                 )
 
-                /*val latLngList: List<LatLng> =
+                val latLngSignalList: List<LatLng> =
                     timelineData.rawSignals.mapNotNull {
-                        it.position?.latLng?.let { latLngString ->
-                            val latLng = latLngString.split(", ")
-                            LatLng(
-                                // latitude =
-                                latLng[0].removeSuffix("°").toDouble(),
-                                // longitude =
-                                latLng[1].removeSuffix("°").toDouble(),
-                            )
-                        }
-                    }*/
+                        it.position?.latLng?.toLatLng()
+                    }
 
                 val latLngVisitList: List<LatLng> =
                     timelineData.semanticSegments.mapNotNull {
@@ -147,14 +139,16 @@ class TimelineDataPresenter
                             it.timelinePath.map { timelinePoint -> timelinePoint.point.toLatLng() }
                         }.flatten()
 
-                return latLngVisitList.plus(latLngPathList).mapIndexed { index, latLng ->
-                    TimelineClusterItem(
-                        itemPosition = latLng,
-                        itemTitle = "Item $index",
-                        itemSnippet = "Snippet $index",
-                        itemZIndex = 0f,
-                    )
-                }
+                return listOf(latLngVisitList, latLngPathList, latLngSignalList)
+                    .flatten()
+                    .mapIndexed { index, latLng ->
+                        TimelineClusterItem(
+                            itemPosition = latLng,
+                            itemTitle = "Item $index",
+                            itemSnippet = "Snippet $index",
+                            itemZIndex = 0f,
+                        )
+                    }
             } ?: Timber.e("Failed to open input stream for URI: $fileUri")
 
             return emptyList()

--- a/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
+++ b/app/src/main/java/dev/hossain/timeline/screens/LocationData.kt
@@ -229,9 +229,10 @@ fun GoogleMapClustering(items: List<TimelineClusterItem>) {
             }
         },
     ) {
-//        DefaultClustering(
-//            items = items,
-//        )
+        // Clustering data is useful for debugging the points on the map.
+        DefaultClustering(
+            items = items,
+        )
 
         MarkerInfoWindow(
             state = rememberMarkerState(position = northAmerica),


### PR DESCRIPTION
This pull request includes changes to the `TimelineDataPresenter` class and the `TimelineClusterItem` data class in the `LocationData.kt` file to improve the processing and conversion of location data.

Improvements to location data processing:

* [`app/src/main/java/dev/hossain/timeline/screens/LocationData.kt`](diffhunk://#diff-a22c4b1c1a546f66adc5f02c30deb5bec45049588746bf628c95634fe5c7061eL121-R144): Refactored the `TimelineDataPresenter` class to use a new `toLatLng` extension function for converting location strings to `LatLng` objects, streamlining the code and improving readability.

Code simplification:

* [`app/src/main/java/dev/hossain/timeline/screens/LocationData.kt`](diffhunk://#diff-a22c4b1c1a546f66adc5f02c30deb5bec45049588746bf628c95634fe5c7061eR301-R308): Added a private extension function `toLatLng` to the `TimelineClusterItem` data class for converting location strings to `LatLng` objects. This reduces code duplication and simplifies the conversion logic.